### PR TITLE
Allow inputNodes to be InputNodes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ export interface TransformNodeInfo extends NodeInfoCommon<"transform"> {
   /**
     Zero or more Broccoli nodes to be used as input to this node.
    */
-  inputNodes: Node[];
+  inputNodes: InputNode[];
 
   /**
     The `Builder` will call this function once before the first build. This


### PR DESCRIPTION
inputNodes can be `string` which this now allows.

cc: @stefanpenner @krisselden 